### PR TITLE
Fix PHP 8.4 PHPDoc deprecation warning

### DIFF
--- a/src/Console/Commands/GenerateCronScheduleCommand.php
+++ b/src/Console/Commands/GenerateCronScheduleCommand.php
@@ -109,7 +109,7 @@ class GenerateCronScheduleCommand extends Command
             /**
              * We have matches, we now loop through them and get the corresponding
              * cron expression.
-             * @var [type]
+             * @var string $match
              */
             foreach ($matches[0] as $key => $match) {
 


### PR DESCRIPTION
## Summary
- Fixed invalid @var [type] annotation in GenerateCronScheduleCommand.php
- Changed to proper @var string $match annotation for the foreach loop variable
- Ensures compatibility with PHP 8.4 by resolving PHPDoc parsing issue

## Changes
- Updated PHPDoc comment from `@var [type]` to `@var string $match`
- No functional changes to the code logic

## Testing
- All PHP files pass syntax validation
- No other PHP 8.4 deprecation issues found in the codebase

Fixes #10